### PR TITLE
Add MySQL compatibility & development compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: '3.7'
+
+services:
+  db-main:
+    image: mysql
+    volumes:
+      - main_mysql_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=main
+    ports:
+      - "3310:3306"
+  db-test:
+    image: mysql
+    volumes:
+      - test_mysql_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=root
+      - MYSQL_DATABASE=test
+    ports:
+      - "3311:3306"
+volumes:
+  main_mysql_data:
+  test_mysql_data:

--- a/readme.md
+++ b/readme.md
@@ -23,12 +23,14 @@ php -v
 
 ### Installing Required PHP Module for CI4
 
+- `mysql`: for connecting with MySQL
 - `curl`: for composer
 - `intl`: for CI4
 - `dom`: for PHPUnit
 - `mbstring`: for PHPUnit
 
 ```
+sudo apt install php8.3-mysql
 sudo apt install php8.3-curl
 sudo apt install php8.3-intl
 sudo apt install php8.3-dom

--- a/readme.md
+++ b/readme.md
@@ -74,5 +74,9 @@ cd source
 ./spark serve
 ```
 
+## Debugging
+- Use provided [Debug Toolbar](https://codeigniter4.github.io/userguide/tutorial/index.html#debug-toolbar)
+- Error logs will be printed on `writable/logs`
+
 ## Useful external resources
 - 25 minutes of [basic MVC in CodeIgniter 4](https://youtu.be/c8zHxE-mN4c?si=pNoCCJwCjGoRfYQp)

--- a/readme.md
+++ b/readme.md
@@ -61,21 +61,29 @@ cd source
 composer install
 ```
 
-### Environment setting
-
-- Copy & rename either `env.dev`, `env.staging`, or `env.prod` to `.env`.
-- Modify as needed
-- Confirm the currently active environment with `./spark env`
-
 ### Running the starter template
+
+Try running the bare minimum settings now with:
 
 ```
 cd source
 ./spark serve
 ```
 
-## Debugging
-- Use provided [Debug Toolbar](https://codeigniter4.github.io/userguide/tutorial/index.html#debug-toolbar)
+A page should now be served at `http://localhost:8080/`.
+
+If you can see the page, then CodeIgniter 4  related modules & packages have been installed successfully.
+
+## Development Configuration
+
+### Environment setting
+
+- Copy & rename `env.dev` to `.env`.
+- Modify as needed
+- Confirm the currently active environment with `./spark env`. It should now shows `development` instead of `production`.
+
+### Debugging
+- Use the provided [Debug Toolbar](https://codeigniter4.github.io/userguide/tutorial/index.html#debug-toolbar)
 - Error logs will be printed on `writable/logs`
 
 ## Useful external resources

--- a/source/env.dev
+++ b/source/env.dev
@@ -30,21 +30,23 @@ CI_ENVIRONMENT = development
 # DATABASE
 #--------------------------------------------------------------------
 
-# database.default.hostname = localhost
-# database.default.database = ci4
-# database.default.username = root
-# database.default.password = root
-# database.default.DBDriver = MySQLi
-# database.default.DBPrefix =
-# database.default.port = 3306
+# Tip: 'localhost' won't work so please use '127.0.0.1'
 
-# database.tests.hostname = localhost
-# database.tests.database = ci4_test
-# database.tests.username = root
-# database.tests.password = root
-# database.tests.DBDriver = MySQLi
-# database.tests.DBPrefix =
-# database.tests.port = 3306
+database.default.hostname = 127.0.0.1
+database.default.database = main
+database.default.username = root
+database.default.password = root
+database.default.DBDriver = MySQLi
+database.default.DBPrefix =
+database.default.port = 3310
+
+database.tests.hostname = 127.0.0.1
+database.tests.database = test
+database.tests.username = root
+database.tests.password = root
+database.tests.DBDriver = MySQLi
+database.tests.DBPrefix =
+database.tests.port = 3311
 
 #--------------------------------------------------------------------
 # CONTENT SECURITY POLICY

--- a/source/env.prod
+++ b/source/env.prod
@@ -30,21 +30,23 @@ CI_ENVIRONMENT = production
 # DATABASE
 #--------------------------------------------------------------------
 
-# database.default.hostname = localhost
-# database.default.database = ci4
-# database.default.username = root
-# database.default.password = root
-# database.default.DBDriver = MySQLi
-# database.default.DBPrefix =
-# database.default.port = 3306
+# Tip: 'localhost' won't work so please use '127.0.0.1'
 
-# database.tests.hostname = localhost
-# database.tests.database = ci4_test
-# database.tests.username = root
-# database.tests.password = root
-# database.tests.DBDriver = MySQLi
-# database.tests.DBPrefix =
-# database.tests.port = 3306
+database.default.hostname = 127.0.0.1
+database.default.database = main
+database.default.username = root
+database.default.password = root
+database.default.DBDriver = MySQLi
+database.default.DBPrefix =
+database.default.port = 3310
+
+database.tests.hostname = 127.0.0.1
+database.tests.database = test
+database.tests.username = root
+database.tests.password = root
+database.tests.DBDriver = MySQLi
+database.tests.DBPrefix =
+database.tests.port = 3311
 
 #--------------------------------------------------------------------
 # CONTENT SECURITY POLICY

--- a/source/env.staging
+++ b/source/env.staging
@@ -30,21 +30,23 @@ CI_ENVIRONMENT = staging
 # DATABASE
 #--------------------------------------------------------------------
 
-# database.default.hostname = localhost
-# database.default.database = ci4
-# database.default.username = root
-# database.default.password = root
-# database.default.DBDriver = MySQLi
-# database.default.DBPrefix =
-# database.default.port = 3306
+# Tip: 'localhost' won't work so please use '127.0.0.1'
 
-# database.tests.hostname = localhost
-# database.tests.database = ci4_test
-# database.tests.username = root
-# database.tests.password = root
-# database.tests.DBDriver = MySQLi
-# database.tests.DBPrefix =
-# database.tests.port = 3306
+database.default.hostname = 127.0.0.1
+database.default.database = main
+database.default.username = root
+database.default.password = root
+database.default.DBDriver = MySQLi
+database.default.DBPrefix =
+database.default.port = 3310
+
+database.tests.hostname = 127.0.0.1
+database.tests.database = test
+database.tests.username = root
+database.tests.password = root
+database.tests.DBDriver = MySQLi
+database.tests.DBPrefix =
+database.tests.port = 3311
 
 #--------------------------------------------------------------------
 # CONTENT SECURITY POLICY


### PR DESCRIPTION
* Add PHP `mysql` module installation step in `readme.md`
* Add `docker-compose.yml` with `main` and `test` MySQL database for local development
* Update `env` template with basic MySQL configuration
* Add development configuration on `readme.md`

closes #5.